### PR TITLE
Add intro layout option with chat-focused home view

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -4,6 +4,12 @@ class PagesController < ApplicationController
   skip_authentication only: :redis_configuration_error
 
   def dashboard
+    if Current.user&.intro?
+      @breadcrumbs = [ [ "Home", nil ] ]
+      render "pages/intro/index"
+      return
+    end
+
     @balance_sheet = Current.family.balance_sheet
     @accounts = Current.family.accounts.visible.with_attached_logo
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,7 +88,7 @@ class UsersController < ApplicationController
     def user_params
       params.require(:user).permit(
         :first_name, :last_name, :email, :profile_image, :redirect_to, :delete_profile_image, :onboarded_at,
-        :show_sidebar, :default_period, :default_account_order, :show_ai_sidebar, :ai_enabled, :theme, :set_onboarding_preferences_at, :set_onboarding_goals_at,
+        :show_sidebar, :default_period, :default_account_order, :show_ai_sidebar, :ai_enabled, :theme, :ui_layout, :set_onboarding_preferences_at, :set_onboarding_goals_at,
         family_attributes: [ :name, :currency, :country, :locale, :date_format, :timezone, :id ],
         goals: []
       )

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,6 +22,9 @@ class User < ApplicationRecord
   normalizes :first_name, :last_name, with: ->(value) { value.strip.presence }
 
   enum :role, { member: "member", admin: "admin", super_admin: "super_admin" }, validate: true
+  enum :ui_layout, { intro: "intro", dashboard: "dashboard" }, validate: true
+
+  attribute :ui_layout, :string, default: "intro"
 
   has_one_attached :profile_image do |attachable|
     attachable.variant :thumbnail, resize_to_fill: [ 300, 300 ], convert: :webp, saver: { quality: 80 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,9 +1,15 @@
+<% intro_ui = Current.user&.intro? %>
 <% mobile_nav_items = [
-  { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
-  { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
-  { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
-  { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
+  { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) }
 ] %>
+
+<% unless intro_ui %>
+  <% mobile_nav_items += [
+    { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
+    { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
+    { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
+  ] %>
+<% end %>
 
 <% desktop_nav_items = mobile_nav_items.reject { |item| item[:mobile_only] } %>
 <% expanded_sidebar_class = "w-full" %>
@@ -16,24 +22,28 @@
     data-app-layout-expanded-sidebar-class="<%= expanded_sidebar_class %>"
     data-app-layout-collapsed-sidebar-class="<%= collapsed_sidebar_class %>"
     data-app-layout-user-id-value="<%= Current.user.id %>">
-    <div
-      class="hidden fixed inset-0 bg-surface z-20 h-full w-full pt-[calc(env(safe-area-inset-top)+0.75rem)] pr-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pl-3 overflow-y-auto transition-all duration-300"
-      data-app-layout-target="mobileSidebar">
-      <div class="mb-2">
-        <%= icon("x", as_button: true, data: { action: "app-layout#closeMobileSidebar" }) %>
-      </div>
+    <% if Current.user&.dashboard? %>
+      <div
+        class="hidden fixed inset-0 bg-surface z-20 h-full w-full pt-[calc(env(safe-area-inset-top)+0.75rem)] pr-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] pl-3 overflow-y-auto transition-all duration-300"
+        data-app-layout-target="mobileSidebar">
+        <div class="mb-2">
+          <%= icon("x", as_button: true, data: { action: "app-layout#closeMobileSidebar" }) %>
+        </div>
 
-      <%= render(
-        "accounts/account_sidebar_tabs",
-        family: Current.family,
-        active_tab: @account_group_tab,
-        mobile: true
-      ) %>
-    </div>
+        <%= render(
+          "accounts/account_sidebar_tabs",
+          family: Current.family,
+          active_tab: @account_group_tab,
+          mobile: true
+        ) %>
+      </div>
+    <% end %>
 
     <%# MOBILE - Top nav %>
     <nav class="lg:hidden flex justify-between items-center p-3">
-      <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
+      <% if Current.user&.dashboard? %>
+        <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
+      <% end %>
 
       <%= link_to root_path, class: "block" do %>
         <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
@@ -52,7 +62,7 @@
         </div>
 
         <ul class="space-y-0.5">
-          <% desktop_nav_items.reject { |item| item[:mobile_only] }.each do |nav_item| %>
+          <% desktop_nav_items.each do |nav_item| %>
             <li>
               <%= render "layouts/shared/nav_item", **nav_item %>
             </li>
@@ -73,40 +83,42 @@
     </div>
 
     <%# DESKTOP - Left sidebar %>
-    <%= tag.div class: class_names(
-        "hidden lg:block py-4 overflow-y-auto shrink-0 max-w-[320px] transition-all duration-300",
-        Current.user.show_sidebar? ? expanded_sidebar_class : collapsed_sidebar_class,
-       ),
-       data: { app_layout_target: "leftSidebar" } do %>
-      <% if content_for?(:sidebar) %>
-        <%= yield :sidebar %>
-      <% else %>
-        <div class="h-full flex flex-col">
-          <div class="overflow-y-auto grow">
-            <%= render "accounts/account_sidebar_tabs", family: Current.family, active_tab: @account_group_tab %>
-          </div>
+    <% if Current.user&.dashboard? %>
+      <%= tag.div class: class_names(
+          "hidden lg:block py-4 overflow-y-auto shrink-0 max-w-[320px] transition-all duration-300",
+          Current.user.show_sidebar? ? expanded_sidebar_class : collapsed_sidebar_class,
+         ),
+         data: { app_layout_target: "leftSidebar" } do %>
+        <% if content_for?(:sidebar) %>
+          <%= yield :sidebar %>
+        <% else %>
+          <div class="h-full flex flex-col">
+            <div class="overflow-y-auto grow">
+              <%= render "accounts/account_sidebar_tabs", family: Current.family, active_tab: @account_group_tab %>
+            </div>
 
-          <% if Current.family.trialing? && !self_hosted? %>
-            <div class="px-4 py-3 space-y-4 bg-container shadow-border-xs rounded-xl">
-              <div class="flex items-start justify-between">
-                <div>
-                  <p class="text-sm font-medium text-primary">Free trial</p>
-                  <p class="text-sm text-secondary"><%= Current.family.days_left_in_trial %> days remaining</p>
+            <% if Current.family.trialing? && !self_hosted? %>
+              <div class="px-4 py-3 space-y-4 bg-container shadow-border-xs rounded-xl">
+                <div class="flex items-start justify-between">
+                  <div>
+                    <p class="text-sm font-medium text-primary">Free trial</p>
+                    <p class="text-sm text-secondary"><%= Current.family.days_left_in_trial %> days remaining</p>
+                  </div>
+
+                  <%= render DS::Link.new(
+                    text: "Upgrade",
+                    href: upgrade_subscription_path,
+                  ) %>
                 </div>
 
-                <%= render DS::Link.new(
-                  text: "Upgrade",
-                  href: upgrade_subscription_path,
-                ) %>
+                <div class="flex items-center gap-0.5 h-1.5">
+                  <div class="h-full bg-warning rounded-full" style="width: <%= Current.family.percentage_of_trial_completed %>%"></div>
+                  <div class="h-full bg-surface-inset rounded-full" style="width: <%= Current.family.percentage_of_trial_remaining %>%"></div>
+                </div>
               </div>
-
-              <div class="flex items-center gap-0.5 h-1.5">
-                <div class="h-full bg-warning rounded-full" style="width: <%= Current.family.percentage_of_trial_completed %>%"></div>
-                <div class="h-full bg-surface-inset rounded-full" style="width: <%= Current.family.percentage_of_trial_remaining %>%"></div>
-              </div>
-            </div>
-          <% end %>
-        </div>
+            <% end %>
+          </div>
+        <% end %>
       <% end %>
     <% end %>
 
@@ -114,7 +126,9 @@
     <%= tag.main class: class_names("grow overflow-y-auto px-3 lg:px-10 py-4 w-full mx-auto max-w-5xl"), data: { app_layout_target: "content" } do %>
       <div class="hidden lg:flex gap-2 items-center justify-between mb-6">
         <div class="flex items-center gap-2">
-          <%= icon("panel-left", as_button: true, data: { action: "app-layout#toggleLeftSidebar" }) %>
+          <% if Current.user&.dashboard? %>
+            <%= icon("panel-left", as_button: true, data: { action: "app-layout#toggleLeftSidebar" }) %>
+          <% end %>
 
           <% if content_for?(:breadcrumbs) %>
             <%= yield :breadcrumbs %>
@@ -122,7 +136,9 @@
             <%= render "layouts/shared/breadcrumbs", breadcrumbs: @breadcrumbs %>
           <% end %>
         </div>
-        <%= icon("panel-right", as_button: true, data: { action: "app-layout#toggleRightSidebar" }) %>
+        <% if Current.user&.dashboard? %>
+          <%= icon("panel-right", as_button: true, data: { action: "app-layout#toggleRightSidebar" }) %>
+        <% end %>
       </div>
 
       <% if content_for?(:page_header) %>
@@ -133,24 +149,26 @@
     <% end %>
 
     <%# DESKTOP - Right sidebar %>
-    <%= tag.div class: class_names(
-          "hidden lg:block h-full overflow-y-auto shrink-0 max-w-[400px] transition-all duration-300",
-          Current.user.show_ai_sidebar? ? expanded_sidebar_class : collapsed_sidebar_class,
-        ),
-        data: { app_layout_target: "rightSidebar" } do %>
-      <%= tag.div id: "chat-container", class: "relative h-full", data: { controller: "chat hotkey", turbo_permanent: true } do %>
-        <div class="flex flex-col h-full justify-between shrink-0">
-          <%= turbo_frame_tag chat_frame, src: chat_view_path(@chat), loading: "lazy", class: "h-full" do %>
-            <div class="flex justify-center items-center h-full">
-              <%= icon("loader-circle", class: "animate-spin") %>
+    <% if Current.user&.dashboard? %>
+      <%= tag.div class: class_names(
+            "hidden lg:block h-full overflow-y-auto shrink-0 max-w-[400px] transition-all duration-300",
+            Current.user.show_ai_sidebar? ? expanded_sidebar_class : collapsed_sidebar_class,
+          ),
+          data: { app_layout_target: "rightSidebar" } do %>
+        <%= tag.div id: "chat-container", class: "relative h-full", data: { controller: "chat hotkey", turbo_permanent: true } do %>
+          <div class="flex flex-col h-full justify-between shrink-0">
+            <%= turbo_frame_tag chat_frame, src: chat_view_path(@chat), loading: "lazy", class: "h-full" do %>
+              <div class="flex justify-center items-center h-full">
+                <%= icon("loader-circle", class: "animate-spin") %>
+              </div>
+            <% end %>
+          </div>
+
+          <% unless Current.user.ai_enabled? %>
+            <div class="absolute backdrop-blur-lg inset-0 h-full w-full flex flex-col justify-center items-center pl-0.5 pr-4">
+              <%= render "chats/ai_consent" %>
             </div>
           <% end %>
-        </div>
-
-        <% unless Current.user.ai_enabled? %>
-          <div class="absolute backdrop-blur-lg inset-0 h-full w-full flex flex-col justify-center items-center pl-0.5 pr-4">
-            <%= render "chats/ai_consent" %>
-          </div>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/pages/intro/index.html.erb
+++ b/app/views/pages/intro/index.html.erb
@@ -1,0 +1,15 @@
+<%= tag.div id: "chat-container", class: "relative h-full", data: { controller: "chat hotkey", turbo_permanent: true } do %>
+  <div class="flex flex-col h-full justify-between shrink-0">
+    <%= turbo_frame_tag chat_frame, src: chat_view_path(@chat), loading: "lazy", class: "h-full" do %>
+      <div class="flex justify-center items-center h-full">
+        <%= icon("loader-circle", class: "animate-spin") %>
+      </div>
+    <% end %>
+  </div>
+
+  <% unless Current.user.ai_enabled? %>
+    <div class="absolute backdrop-blur-lg inset-0 h-full w-full flex flex-col justify-center items-center pl-0.5 pr-4">
+      <%= render "chats/ai_consent" %>
+    </div>
+  <% end %>
+<% end %>

--- a/db/migrate/20250808150000_add_ui_layout_to_users.rb
+++ b/db/migrate/20250808150000_add_ui_layout_to_users.rb
@@ -1,0 +1,12 @@
+class AddUiLayoutToUsers < ActiveRecord::Migration[7.1]
+  def up
+    add_column :users, :ui_layout, :string, null: false, default: "intro"
+    execute <<~SQL.squish
+      UPDATE users SET ui_layout = 'dashboard'
+    SQL
+  end
+
+  def down
+    remove_column :users, :ui_layout
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
+ActiveRecord::Schema[7.2].define(version: 2025_08_08_150000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -845,6 +845,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_08_08_143007) do
     t.boolean "show_ai_sidebar", default: true
     t.boolean "ai_enabled", default: false, null: false
     t.string "theme", default: "system"
+    t.string "ui_layout", default: "intro", null: false
     t.boolean "rule_prompts_disabled", default: false
     t.datetime "rule_prompt_dismissed_at"
     t.text "goals", default: [], array: true

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,6 +7,7 @@ empty:
   onboarded_at: <%= 3.days.ago %>
   role: admin
   ai_enabled: true
+  ui_layout: dashboard
 
 maybe_support_staff:
   family: empty
@@ -17,6 +18,7 @@ maybe_support_staff:
   role: super_admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  ui_layout: dashboard
 
 family_admin:
   family: dylan_family
@@ -27,6 +29,7 @@ family_admin:
   role: admin
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  ui_layout: dashboard
 
 family_member:
   family: dylan_family
@@ -36,6 +39,7 @@ family_member:
   password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
   onboarded_at: <%= 3.days.ago %>
   ai_enabled: true
+  ui_layout: dashboard
 
 new_email:
   family: empty
@@ -43,6 +47,7 @@ new_email:
   last_name: User
   email: user@example.com
   unconfirmed_email: new@example.com
-  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla 
+  password_digest: $2a$12$XoNBo/cMCyzpYtvhrPAhsubG21mELX48RAcjSVCRctW8dG8wrDIla
   onboarded_at: <%= Time.current %>
   ai_enabled: true
+  ui_layout: dashboard

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -9,6 +9,10 @@ class UserTest < ActiveSupport::TestCase
     assert @user.valid?, @user.errors.full_messages.to_sentence
   end
 
+  test "ui layout defaults to intro" do
+    assert_equal "intro", User.new.ui_layout
+  end
+
   # email
   test "email must be present" do
     potential_user = User.new(


### PR DESCRIPTION
## Summary
- add a persisted `ui_layout` enum for users with a default of the new intro view
- render a chat-focused intro page from the dashboard action when the intro layout is selected
- update the application layout so the intro view only shows the home nav shortcut and chat panel

## Testing
- `bin/rails test` *(fails: lucide-rails git dependency requires `bundle install` which cannot complete without network access)*
- `bin/rubocop` *(fails: lucide-rails git dependency requires `bundle install` which cannot complete without network access)*

------
https://chatgpt.com/codex/tasks/task_e_68ca840208948332badf234f6c080ea7