### PR TITLE
Simplify mobile dashboard navigation

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,6 @@
 <% mobile_nav_items = [
-  { name: "Home", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) },
-  { name: "Transactions", path: transactions_path, icon: "credit-card", icon_custom: false, active: page_active?(transactions_path) },
-  { name: "Budgets", path: budgets_path, icon: "map", icon_custom: false, active: page_active?(budgets_path) },
-  { name: "Assistant", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true }
+  { name: "Companion", path: chats_path, icon: "icon-assistant", icon_custom: true, active: page_active?(chats_path), mobile_only: true },
+  { name: "Insights*", path: root_path, icon: "pie-chart", icon_custom: false, active: page_active?(root_path) }
 ] %>
 
 <% desktop_nav_items = mobile_nav_items.reject { |item| item[:mobile_only] } %>
@@ -33,8 +31,6 @@
 
     <%# MOBILE - Top nav %>
     <nav class="lg:hidden flex justify-between items-center p-3">
-      <%= icon("panel-left", as_button: true, data: { action: "app-layout#openMobileSidebar"}) %>
-
       <%= link_to root_path, class: "block" do %>
         <%= image_tag "logomark-color.svg", class: "w-9 h-9 mx-auto" %>
       <% end %>


### PR DESCRIPTION
## Summary
- streamline the mobile navigation menu to show only Companion and Insights*
- remove the mobile sidebar toggle button from the header to match the simplified layout

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dbb1871a908332934d0a8c1016ae7f