### PR TITLE
Add consent details page for partner registration

### DIFF
--- a/app/controllers/partner_registrations_controller.rb
+++ b/app/controllers/partner_registrations_controller.rb
@@ -10,6 +10,8 @@ class PartnerRegistrationsController < RegistrationsController
 
   def privacy; end
 
+  def consent; end
+
   def create
     if @invitation
       @user.family = @invitation.family

--- a/app/views/partner_registrations/consent.html.erb
+++ b/app/views/partner_registrations/consent.html.erb
@@ -1,0 +1,73 @@
+<%
+  header_title current_partner&.translation(:registration, :consent, :heading, default: t(".heading"))
+%>
+<br />
+<br />
+<div class="max-w-3xl mx-auto space-y-8 bg-surface-inset border border-secondary rounded-2xl p-8 text-primary">
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :what_is_this_about, :title, default: t(".sections.what_is_this_about.title")) %></h2>
+    <p class="text-secondary leading-relaxed"><%= current_partner&.translation(:registration, :consent, :sections, :what_is_this_about, :body, default: t(".sections.what_is_this_about.body")) %></p>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :data_collection, :title, default: t(".sections.data_collection.title")) %></h2>
+    <p class="text-secondary leading-relaxed"><%= current_partner&.translation(:registration, :consent, :sections, :data_collection, :intro, default: t(".sections.data_collection.intro")) %></p>
+    <ul class="list-disc pl-6 space-y-2 text-secondary leading-relaxed">
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :data_collection, :bullets, :email, default: t(".sections.data_collection.bullets.email")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :data_collection, :bullets, :conversations, default: t(".sections.data_collection.bullets.conversations")) %></li>
+    </ul>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :data_use, :title, default: t(".sections.data_use.title")) %></h2>
+    <ul class="list-disc pl-6 space-y-2 text-secondary leading-relaxed">
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :data_use, :bullets, :email, default: t(".sections.data_use.bullets.email")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :data_use, :bullets, :conversations, default: t(".sections.data_use.bullets.conversations")) %></li>
+    </ul>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :privacy_protection, :title, default: t(".sections.privacy_protection.title")) %></h2>
+    <ul class="list-disc pl-6 space-y-2 text-secondary leading-relaxed">
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :privacy_protection, :bullets, :anonymised, default: t(".sections.privacy_protection.bullets.anonymised")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :privacy_protection, :bullets, :personalisation, default: t(".sections.privacy_protection.bullets.personalisation")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :privacy_protection, :bullets, :security, default: t(".sections.privacy_protection.bullets.security")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :privacy_protection, :bullets, :compliance, default: t(".sections.privacy_protection.bullets.compliance")) %></li>
+    </ul>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :your_rights, :title, default: t(".sections.your_rights.title")) %></h2>
+    <ul class="list-disc pl-6 space-y-2 text-secondary leading-relaxed">
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :your_rights, :bullets, :correction, default: t(".sections.your_rights.bullets.correction")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :your_rights, :bullets, :withdraw, default: t(".sections.your_rights.bullets.withdraw")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :your_rights, :bullets, :questions, default: t(".sections.your_rights.bullets.questions")) %></li>
+    </ul>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :voluntary_participation, :title, default: t(".sections.voluntary_participation.title")) %></h2>
+    <ul class="list-disc pl-6 space-y-2 text-secondary leading-relaxed">
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :voluntary_participation, :bullets, :voluntary, default: t(".sections.voluntary_participation.bullets.voluntary")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :voluntary_participation, :bullets, :stop_anytime, default: t(".sections.voluntary_participation.bullets.stop_anytime")) %></li>
+      <li><%= current_partner&.translation(:registration, :consent, :sections, :voluntary_participation, :bullets, :no_effect, default: t(".sections.voluntary_participation.bullets.no_effect")) %></li>
+    </ul>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :data_retention, :title, default: t(".sections.data_retention.title")) %></h2>
+    <p class="text-secondary leading-relaxed"><%= current_partner&.translation(:registration, :consent, :sections, :data_retention, :body, default: t(".sections.data_retention.body")) %></p>
+  </section>
+
+  <section class="space-y-2">
+    <h2 class="text-xl font-semibold text-primary"><%= current_partner&.translation(:registration, :consent, :sections, :your_consent, :title, default: t(".sections.your_consent.title")) %></h2>
+    <p class="text-secondary leading-relaxed"><%= current_partner&.translation(:registration, :consent, :sections, :your_consent, :body, default: t(".sections.your_consent.body")) %></p>
+  </section>
+
+  <div class="flex flex-col gap-3 pt-4 sm:flex-row">
+    <%= render DS::Link.new(text: current_partner&.translation(:registration, :consent, :agree_cta, default: t(".agree_cta")), href: new_session_path(partner_key: @partner.key), variant: :primary, full_width: true, class: "sm:w-1/2") %>
+    <%= render DS::Link.new(text: current_partner&.translation(:registration, :consent, :back_cta, default: t(".back_cta")), href: privacy_partner_registration_path(partner_key: @partner.key), variant: :ghost, full_width: true, class: "sm:w-1/2") %>
+  </div>
+
+  <p class="text-xs text-secondary text-center"><%= current_partner&.translation(:registration, :consent, :compliance_notice, default: t(".compliance_notice")) %></p>
+</div>

--- a/app/views/partner_registrations/privacy.html.erb
+++ b/app/views/partner_registrations/privacy.html.erb
@@ -22,6 +22,6 @@
 
   <div class="flex flex-col gap-3 pt-4 sm:flex-row">
     <%= render DS::Link.new(text: current_partner&.translation(:registration, :privacy, :agree_cta, default: t(".agree_cta")), href: new_session_path(partner_key: @partner.key), variant: :primary, full_width: true, class: "sm:w-1/2") %>
-    <%= render DS::Link.new(text: current_partner&.translation(:registration, :privacy, :learn_more_cta, default: t(".learn_more_cta")), href: "about:blank", variant: :primary, full_width: true, class: "sm:w-1/2") %>
+    <%= render DS::Link.new(text: current_partner&.translation(:registration, :privacy, :learn_more_cta, default: t(".learn_more_cta")), href: consent_partner_registration_path(partner_key: @partner.key), variant: :primary, full_width: true, class: "sm:w-1/2") %>
   </div>
 </div>

--- a/config/locales/views/partner_registrations/en.yml
+++ b/config/locales/views/partner_registrations/en.yml
@@ -35,3 +35,48 @@ en:
       agreement: "By continuing, you agree to participate in this preview version."
       agree_cta: "I Agree & Continue"
       learn_more_cta: "Learn More"
+    consent:
+      heading: "Member Consent Form"
+      sections:
+        what_is_this_about:
+          title: "What Is This About?"
+          body: "We are pre-launching a financial literacy mobile application to help our members improve their money management skills, including the impact of the Chancen ISA. The first feature we are introducing is an AI chatbot that answers your Chancen ISA and financial questions. We invite you to participate in this pre-launch phase to help us improve the app. This form explains what information we collect and how we use it."
+        data_collection:
+          title: "What Information Do We Collect?"
+          intro: "When you participate in our pre-launch, we collect:"
+          bullets:
+            email: "Your email address - to create your account and contact you if needed"
+            conversations: "Your conversations with the chatbot - we record the full content of your chats with the bot, but we remove your name and identifying details before analysis"
+        data_use:
+          title: "How Do We Use Your Information?"
+          bullets:
+            email: "Email address: Account creation, communication about the app, and product updates"
+            conversations: "Chat conversations: We analyse the content to understand how our members use the chatbot, identify what works well, and make improvements to help current and future members learn better"
+        privacy_protection:
+          title: "How We Protect Your Privacy"
+          bullets:
+            anonymised: "Your chat conversations are anonymised - your name is removed before our team reviews them"
+            personalisation: "The chatbot can still personalise responses to you during and across sessions"
+            security: "We store your data securely, and only authorised team members can access it"
+            compliance: "We comply with the Kenya Data Protection Act, 2019"
+        your_rights:
+          title: "Your Rights"
+          bullets:
+            correction: "Request correction of any incorrect information"
+            withdraw: "Withdraw your consent and request deletion of your data at any time"
+            questions: "Ask questions about how we process your data"
+        voluntary_participation:
+          title: "Voluntary Participation"
+          bullets:
+            voluntary: "Your participation is completely voluntary"
+            stop_anytime: "You can stop using the app at any time"
+            no_effect: "Choosing not to participate will not affect you negatively in any way"
+        data_retention:
+          title: "Data Retention"
+          body: "We will keep your data only as long as necessary for product improvement purposes. You may request deletion of your data at any time by contacting us."
+        your_consent:
+          title: "Your Consent"
+          body: "By agreeing below, I confirm that I have read and understood this consent form, understand what information is being collected and how it will be used, voluntarily agree to participate in this pre-launch, understand I can withdraw my consent at any time, confirm that I am 18 years old or above, and agree to the terms and conditions mentioned in this document."
+      agree_cta: "I Agree"
+      back_cta: "Back"
+      compliance_notice: "This consent form complies with the Kenya Data Protection Act, 2019."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     resource :registration, only: %i[new create], controller: "partner_registrations" do
       get :welcome
       get :privacy
+      get :consent
     end
 
     resource :onboarding, only: :show, controller: "partner_onboardings" do

--- a/test/controllers/partner_registrations_controller_test.rb
+++ b/test/controllers/partner_registrations_controller_test.rb
@@ -15,7 +15,14 @@ class PartnerRegistrationsControllerTest < ActionDispatch::IntegrationTest
     get privacy_partner_registration_url(partner_key: @partner_key)
     assert_response :success
     assert_select "a[href='#{new_session_path(partner_key: @partner_key)}']", text: I18n.t("partner_registrations.privacy.agree_cta")
-    assert_select "a[href='about:blank']", text: I18n.t("partner_registrations.privacy.learn_more_cta")
+    assert_select "a[href='#{consent_partner_registration_path(partner_key: @partner_key)}']", text: I18n.t("partner_registrations.privacy.learn_more_cta")
+  end
+
+  test "consent" do
+    get consent_partner_registration_url(partner_key: @partner_key)
+    assert_response :success
+    assert_select "h2", text: I18n.t("partner_registrations.consent.sections.what_is_this_about.title")
+    assert_select "a[href='#{new_session_path(partner_key: @partner_key)}']", text: I18n.t("partner_registrations.consent.agree_cta")
   end
 
   test "new" do


### PR DESCRIPTION
## Summary
- add a dedicated consent route and action for partner registrations
- create the consent view with detailed member consent copy and supporting translations
- wire the privacy screen "Learn More" link to the new page and extend controller tests

## Testing
- bin/rails test test/controllers/partner_registrations_controller_test.rb *(fails: missing tailwind.css asset in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38fc1c0048332a167bfb2b974fe17