### PR TITLE
Add rake task to bulk provision partner users

### DIFF
--- a/app/services/bulk/user_account_creator.rb
+++ b/app/services/bulk/user_account_creator.rb
@@ -1,0 +1,134 @@
+require "securerandom"
+require "uri"
+
+module Bulk
+  class UserAccountCreator
+    Result = Struct.new(:status, :email, :user, :message, :error, keyword_init: true)
+
+    FAMILY_ATTRIBUTE_KEYS = %w[currency locale country date_format timezone].freeze
+
+    def initialize(partner:)
+      raise ArgumentError, "partner is required" if partner.blank?
+
+      @partner = partner
+      ensure_required_metadata_present!
+    end
+
+    def call(email)
+      normalized_email = normalize_email(email)
+
+      if normalized_email.blank?
+        return Result.new(status: :skipped, email: normalized_email, message: "Email is blank")
+      end
+
+      unless valid_email?(normalized_email)
+        return Result.new(status: :error, email: normalized_email.presence || email.to_s, message: "Invalid email format")
+      end
+
+      if User.exists?(email: normalized_email)
+        return Result.new(status: :skipped, email: normalized_email, message: "User already exists")
+      end
+
+      user = nil
+
+      ActiveRecord::Base.transaction do
+        family = create_family!(normalized_email)
+        user = build_user(family, normalized_email)
+        user.save!
+      end
+
+      Result.new(status: :created, email: normalized_email, user: user)
+    rescue ActiveRecord::RecordInvalid => error
+      Result.new(
+        status: :error,
+        email: normalized_email,
+        error: error,
+        message: error.record.errors.full_messages.to_sentence.presence || error.message
+      )
+    end
+
+    private
+
+      attr_reader :partner
+
+      def normalize_email(email)
+        email.to_s.strip.downcase
+      end
+
+      def valid_email?(email)
+        URI::MailTo::EMAIL_REGEXP.match?(email)
+      end
+
+      def create_family!(email)
+        attributes = family_attributes_for(email)
+        Family.create!(attributes)
+      end
+
+      def build_user(family, email)
+        user = family.users.new(
+          email: email,
+          role: :admin,
+          password: SecureRandom.hex(16)
+        )
+
+        apply_partner_defaults(user)
+        user
+      end
+
+      def apply_partner_defaults(user)
+        metadata = partner_metadata_for_user
+
+        if (layout = metadata.delete("ui_layout"))
+          layout = layout.presence
+          user.ui_layout = layout if layout
+        end
+
+        user.partner_metadata = metadata if metadata.present?
+
+        partner.user_defaults.each do |attribute, value|
+          setter = "#{attribute}="
+          next unless user.respond_to?(setter)
+
+          current_value = user.respond_to?(attribute) ? user.public_send(attribute) : nil
+          next if current_value == value
+
+          user.public_send(setter, value)
+        end
+      end
+
+      def partner_metadata_for_user
+        metadata = partner.default_metadata.deep_dup
+        metadata["key"] ||= partner.key
+        metadata["name"] ||= partner.name
+        metadata["type"] ||= partner.type
+        metadata
+      end
+
+      def family_attributes_for(email)
+        metadata = partner.default_metadata
+        attributes = metadata.slice(*FAMILY_ATTRIBUTE_KEYS).compact
+        attributes.transform_keys!(&:to_sym)
+        attributes[:name] = default_family_name(email)
+        attributes
+      end
+
+      def default_family_name(email)
+        local_part = email.to_s.split("@").first
+        return email if local_part.blank?
+
+        normalized = local_part.tr("._-", " ").squeeze(" ").strip
+        return "#{normalized.titleize} Household" if normalized.present?
+
+        email
+      end
+
+      def ensure_required_metadata_present!
+        metadata = partner_metadata_for_user
+        missing = partner.required_metadata_keys - metadata.keys
+
+        return if missing.empty?
+
+        raise ArgumentError, "Partner #{partner.key} is missing required metadata keys: #{missing.join(", ")}"
+      end
+  end
+end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -2,7 +2,7 @@ require "json"
 
 namespace :bulk do
   desc "Create empty partner accounts for a list of email addresses"
-  task :add_users, [:partner_key, :emails] => :environment do |_task, args|
+  task :add_users, [ :partner_key, :emails ] => :environment do |_task, args|
     args.with_defaults(
       partner_key: ENV["partner_key"] || ENV["PARTNER_KEY"],
       emails: ENV["emails"] || ENV["EMAILS"]

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -1,0 +1,84 @@
+require "json"
+
+namespace :bulk do
+  desc "Create empty partner accounts for a list of email addresses"
+  task :add_users, [:partner_key, :emails] => :environment do |_task, args|
+    args.with_defaults(
+      partner_key: ENV["partner_key"] || ENV["PARTNER_KEY"],
+      emails: ENV["emails"] || ENV["EMAILS"]
+    )
+
+    partner_key = args[:partner_key].to_s.strip
+
+    if partner_key.blank?
+      abort "Partner key is required. Provide as rake bulk:add_users[partner_key,emails] or PARTNER_KEY=..."
+    end
+
+    partner = Partners.find(partner_key)
+
+    unless partner
+      available = Partners.all.keys
+      abort "Unknown partner '#{partner_key}'. Available partners: #{available.join(", ")}"
+    end
+
+    raw_emails = parse_emails_argument(args[:emails])
+
+    if raw_emails.empty?
+      abort "No email addresses provided. Pass a JSON array or comma-separated list as the second argument."
+    end
+
+    creator = Bulk::UserAccountCreator.new(partner: partner)
+
+    summary = Hash.new(0)
+
+    raw_emails.each do |email|
+      result = creator.call(email)
+      status = result.status || :unknown
+      summary[status] += 1
+
+      case status
+      when :created
+        puts "✅ Created account for #{result.email}"
+      when :skipped
+        puts "⚠️  Skipped #{result.email.presence || email}: #{result.message}"
+      when :error
+        message = result.message || result.error&.message || "Unknown error"
+        puts "❌ Failed to create account for #{result.email.presence || email}: #{message}"
+      else
+        puts "⚠️  Received unexpected status '#{result.status}' for #{result.email.presence || email}"
+      end
+    end
+
+    puts
+    puts "Summary:"
+    puts "  Created: #{summary[:created]}"
+    puts "  Skipped: #{summary[:skipped]}"
+    puts "  Errors:  #{summary[:error]}"
+
+    exit(1) if summary[:error].positive?
+  end
+
+  def parse_emails_argument(argument)
+    value = argument
+
+    if value.respond_to?(:to_a) && !value.is_a?(String)
+      list = value.to_a
+    else
+      raw = value.to_s.strip
+      return [] if raw.blank?
+
+      list = parse_json_array(raw) || raw.split(/[,;\s]+/)
+    end
+
+    list.filter_map { |item| item.to_s.strip.presence }.uniq
+  end
+
+  def parse_json_array(value)
+    parsed = JSON.parse(value)
+    return parsed if parsed.is_a?(Array)
+
+    nil
+  rescue JSON::ParserError
+    nil
+  end
+end

--- a/lib/tasks/bulk.rake
+++ b/lib/tasks/bulk.rake
@@ -21,7 +21,10 @@ namespace :bulk do
       abort "Unknown partner '#{partner_key}'. Available partners: #{available.join(", ")}"
     end
 
-    raw_emails = parse_emails_argument(args[:emails])
+    email_inputs = [ args[:emails] ]
+    email_inputs.concat(args.extras) if args.respond_to?(:extras)
+
+    raw_emails = email_inputs.flat_map { |value| parse_emails_argument(value) }.uniq
 
     if raw_emails.empty?
       abort "No email addresses provided. Pass a JSON array or comma-separated list as the second argument."

--- a/test/services/bulk/user_account_creator_test.rb
+++ b/test/services/bulk/user_account_creator_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Bulk::UserAccountCreatorTest < ActiveSupport::TestCase
+  setup do
+    Partners.reset!
+    @partner = Partners.find("chancen-ke")
+    @creator = Bulk::UserAccountCreator.new(partner: @partner)
+  end
+
+  test "creates a family and admin user with partner defaults" do
+    result = @creator.call("new-partner-user@example.com")
+
+    assert_equal :created, result.status
+
+    user = result.user
+    assert user.persisted?
+    assert_equal "new-partner-user@example.com", user.email
+    assert_equal "chancen-ke", user.partner_key
+    assert_equal "KES", user.family.currency
+    assert_equal "%d/%m/%Y", user.family.date_format
+    assert_equal "intro", user.ui_layout
+    assert user.ai_enabled?
+    assert_equal "Chancen Kenya", user.partner_name
+  end
+
+  test "skips existing users" do
+    existing_email = users(:empty).email
+
+    result = @creator.call(existing_email)
+
+    assert_equal :skipped, result.status
+    assert_equal "User already exists", result.message
+  end
+
+  test "returns an error for invalid emails" do
+    result = @creator.call("invalid-email")
+
+    assert_equal :error, result.status
+    assert_equal "Invalid email format", result.message
+  end
+end

--- a/test/tasks/bulk_add_users_task_test.rb
+++ b/test/tasks/bulk_add_users_task_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+require "rake"
+
+class BulkAddUsersTaskTest < ActiveSupport::TestCase
+  setup do
+    Rake.application = Rake::Application.new
+    load Rails.root.join("lib/tasks/bulk.rake")
+  end
+
+  test "parse_emails_argument handles comma separated string" do
+    result = send(:parse_emails_argument, "one@example.com,two@example.com")
+    assert_equal ["one@example.com", "two@example.com"], result
+  end
+
+  test "parse_emails_argument handles json array" do
+    result = send(:parse_emails_argument, '["one@example.com","two@example.com"]')
+    assert_equal ["one@example.com", "two@example.com"], result
+  end
+
+  test "task arguments collect positional emails" do
+    args = Rake::TaskArguments.new([:partner_key, :emails], ["partner", "one@example.com", "two@example.com"])
+    args.with_defaults(partner_key: nil, emails: nil)
+
+    email_inputs = [args[:emails]]
+    email_inputs.concat(args.extras) if args.respond_to?(:extras)
+
+    result = email_inputs.flat_map { |value| send(:parse_emails_argument, value) }.uniq
+
+    assert_equal ["one@example.com", "two@example.com"], result
+  end
+end

--- a/test/tasks/bulk_add_users_task_test.rb
+++ b/test/tasks/bulk_add_users_task_test.rb
@@ -9,23 +9,23 @@ class BulkAddUsersTaskTest < ActiveSupport::TestCase
 
   test "parse_emails_argument handles comma separated string" do
     result = send(:parse_emails_argument, "one@example.com,two@example.com")
-    assert_equal ["one@example.com", "two@example.com"], result
+    assert_equal [ "one@example.com", "two@example.com" ], result
   end
 
   test "parse_emails_argument handles json array" do
     result = send(:parse_emails_argument, '["one@example.com","two@example.com"]')
-    assert_equal ["one@example.com", "two@example.com"], result
+    assert_equal [ "one@example.com", "two@example.com" ], result
   end
 
   test "task arguments collect positional emails" do
-    args = Rake::TaskArguments.new([:partner_key, :emails], ["partner", "one@example.com", "two@example.com"])
+    args = Rake::TaskArguments.new([ :partner_key, :emails ], [ "partner", "one@example.com", "two@example.com" ])
     args.with_defaults(partner_key: nil, emails: nil)
 
-    email_inputs = [args[:emails]]
+    email_inputs = [ args[:emails] ]
     email_inputs.concat(args.extras) if args.respond_to?(:extras)
 
     result = email_inputs.flat_map { |value| send(:parse_emails_argument, value) }.uniq
 
-    assert_equal ["one@example.com", "two@example.com"], result
+    assert_equal [ "one@example.com", "two@example.com" ], result
   end
 end


### PR DESCRIPTION
## Summary
- add a Bulk::UserAccountCreator service that builds families and partner-configured admin users
- add a rake bulk:add_users task to provision accounts for a list of emails tied to a partner
- cover the new service with tests

## Testing
- bin/rails test test/services/bulk/user_account_creator_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68e64afd9d988332b73599adcdfc4187