### PR TITLE
Add workflow to verify companion chatbot response

### DIFF
--- a/.github/workflows/companion-chat-check.yml
+++ b/.github/workflows/companion-chat-check.yml
@@ -1,0 +1,30 @@
+name: Companion Chat Monitor
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  chat-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright
+        run: npm install --no-save playwright@1.44.1
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Verify companion chatbot response
+        env:
+          COMPANION_EMAIL: juanjo.mata2@gmail.com
+          COMPANION_PASSWORD: Password1!
+        run: node bin/check_companion_chat.js

--- a/.github/workflows/companion-chat-check.yml
+++ b/.github/workflows/companion-chat-check.yml
@@ -3,7 +3,7 @@ name: Companion Chat Monitor
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '22 * * * *'
 
 jobs:
   chat-check:

--- a/bin/check_companion_chat.js
+++ b/bin/check_companion_chat.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const { chromium } = require('playwright');
+
+async function run() {
+  const email = process.env.COMPANION_EMAIL;
+  const password = process.env.COMPANION_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error('Missing COMPANION_EMAIL or COMPANION_PASSWORD environment variables');
+  }
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(60000);
+  page.setDefaultNavigationTimeout(60000);
+
+  try {
+    await page.goto('https://companion.chancen.tech/sessions/new', { waitUntil: 'networkidle' });
+
+    await page.fill('input[name="session[email]"]', email);
+    await page.fill('input[name="session[password]"]', password);
+
+    await page.click('button[type="submit"]');
+    await page.waitForLoadState('networkidle', { timeout: 60000 });
+
+    // Ensure we are authenticated by navigating to the chats page explicitly.
+    await page.goto('https://companion.chancen.tech/chats/new', { waitUntil: 'networkidle' });
+
+    const chatFormSelector = '#chat-form textarea';
+    await page.waitForSelector(chatFormSelector, { timeout: 30000 });
+
+    await page.fill(chatFormSelector, 'Hi');
+
+    await Promise.all([
+      page.waitForURL((url) => url.includes('/chats/'), { waitUntil: 'networkidle' }),
+      page.click('#chat-form button[type="submit"]'),
+    ]);
+
+    const assistantSelector = '#messages [id^="assistant_message_"] .prose--ai-chat';
+
+    await page.waitForSelector('#messages', { timeout: 30000 });
+
+    const initialAssistantCount = await page.locator(assistantSelector).count();
+
+    await page.waitForFunction(
+      ({ selector, minimumCount }) => {
+        return document.querySelectorAll(selector).length > minimumCount;
+      },
+      { selector: assistantSelector, minimumCount: initialAssistantCount },
+      { timeout: 120000 }
+    );
+
+    const assistantMessages = page.locator(assistantSelector);
+    const latestMessage = await assistantMessages.nth(-1).innerText();
+
+    if (!latestMessage || latestMessage.trim().length === 0) {
+      throw new Error('Assistant response is empty');
+    }
+
+    console.log('Assistant responded with:', latestMessage.trim());
+  } finally {
+    await browser.close();
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a scheduled/manual GitHub Action that exercises the companion chatbot via Playwright
- create a headless Playwright script that logs in, starts a chat with "Hi", and asserts that a response arrives

## Testing
- not run (workflow automation only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914a077e1e08332a58dc47f02101de6)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211929668077133