### PR TITLE
Fix: Allow users to copy text from chatbot responses

### DIFF
--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -400,8 +400,10 @@ class _MessageBubble extends StatelessWidget {
             child: Column(
               crossAxisAlignment: isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
               children: [
-                Container(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                SelectionArea(
+                  child: Container(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
                   decoration: BoxDecoration(
                     color: isUser ? colorScheme.primary : colorScheme.surfaceContainerHighest,
                     borderRadius: BorderRadius.circular(16),
@@ -435,6 +437,7 @@ class _MessageBubble extends StatelessWidget {
                         ),
                     ],
                   ),
+                ),
                 ),
                 const SizedBox(height: 4),
                 Text(

--- a/mobile/lib/screens/chat_conversation_screen.dart
+++ b/mobile/lib/screens/chat_conversation_screen.dart
@@ -400,44 +400,46 @@ class _MessageBubble extends StatelessWidget {
             child: Column(
               crossAxisAlignment: isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
               children: [
-                SelectionArea(
-                  child: Container(
-                  padding:
-                      const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-                  decoration: BoxDecoration(
-                    color: isUser ? colorScheme.primary : colorScheme.surfaceContainerHighest,
-                    borderRadius: BorderRadius.circular(16),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        message.content,
-                        style: TextStyle(
-                          color: isUser ? colorScheme.onPrimary : colorScheme.onSurfaceVariant,
-                        ),
+                Builder(
+                  builder: (context) {
+                    final bubble = Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                      decoration: BoxDecoration(
+                        color: isUser ? colorScheme.primary : colorScheme.surfaceContainerHighest,
+                        borderRadius: BorderRadius.circular(16),
                       ),
-                      if (message.toolCalls != null && message.toolCalls!.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8),
-                          child: Wrap(
-                            spacing: 4,
-                            runSpacing: 4,
-                            children: message.toolCalls!.map((toolCall) {
-                              return Chip(
-                                label: Text(
-                                  toolCall.functionName,
-                                  style: const TextStyle(fontSize: 11),
-                                ),
-                                padding: EdgeInsets.zero,
-                                visualDensity: VisualDensity.compact,
-                              );
-                            }).toList(),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            message.content,
+                            style: TextStyle(
+                              color: isUser ? colorScheme.onPrimary : colorScheme.onSurfaceVariant,
+                            ),
                           ),
-                        ),
-                    ],
-                  ),
-                ),
+                          if (message.toolCalls != null && message.toolCalls!.isNotEmpty)
+                            Padding(
+                              padding: const EdgeInsets.only(top: 8),
+                              child: Wrap(
+                                spacing: 4,
+                                runSpacing: 4,
+                                children: message.toolCalls!.map((toolCall) {
+                                  return Chip(
+                                    label: Text(
+                                      toolCall.functionName,
+                                      style: const TextStyle(fontSize: 11),
+                                    ),
+                                    padding: EdgeInsets.zero,
+                                    visualDensity: VisualDensity.compact,
+                                  );
+                                }).toList(),
+                              ),
+                            ),
+                        ],
+                      ),
+                    );
+                    return isUser ? bubble : SelectionArea(child: bubble);
+                  },
                 ),
                 const SizedBox(height: 4),
                 Text(


### PR DESCRIPTION
## Summary
- Wraps assistant message bubbles in `SelectionArea` to enable native OS text selection
- Users can now tap and drag to select specific portions of the chatbot's response
- The OS copy toolbar appears on selection, allowing standard copy behaviour

## Test plan
- [ ] Open a chat conversation and long-press / drag over assistant response text
- [ ] Verify selection handles appear and text can be highlighted
- [ ] Verify the OS copy toolbar appears with a Copy option
- [ ] Verify user message bubbles are unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Incoming (left-side) chat messages now support text selection and copy to clipboard for easier sharing and reference; outgoing (your) message bubbles remain unchanged and are not selectable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->