### PR TITLE
Honor default family and invitation precedence for API and SSO signups

### DIFF
--- a/app/controllers/api/v1/auth_controller.rb
+++ b/app/controllers/api/v1/auth_controller.rb
@@ -12,6 +12,9 @@ module Api
       before_action :log_api_access, only: :enable_ai
 
       def signup
+        # invite_code_required? consults @invitation, so resolve it before checking invite-code requirements.
+        @invitation = pending_invitation_from_params
+
         # Check if invite code is required
         if invite_code_required? && params[:invite_code].blank?
           render json: { error: "Invite code is required" }, status: :forbidden
@@ -39,25 +42,27 @@ module Api
 
         user = User.new(user_signup_params)
 
-        # Create family for new user
-        # First user of an instance becomes super_admin
-        family = Family.new
-        user.family = family
-        user.role = User.role_for_new_family_creator
+        assign_signup_family_and_role(user, invitation: @invitation)
 
-        if user.save
-          # Claim invite code if provided
-          InviteCode.claim!(params[:invite_code]) if params[:invite_code].present?
+        token_response = nil
 
-          # Create device and OAuth token
-          begin
+        begin
+          ActiveRecord::Base.transaction do
+            unless user.save
+              raise ActiveRecord::Rollback
+            end
+
+            InviteCode.claim!(params[:invite_code]) if params[:invite_code].present?
+            @invitation&.update!(accepted_at: Time.current)
             device = MobileDevice.upsert_device!(user, device_params)
             token_response = device.issue_token!
-          rescue ActiveRecord::RecordInvalid => e
-            render json: { error: "Failed to register device: #{e.message}" }, status: :unprocessable_entity
-            return
           end
+        rescue ActiveRecord::RecordInvalid => e
+          render json: { error: "Failed to register device: #{e.message}" }, status: :unprocessable_entity
+          return
+        end
 
+        if user.persisted? && token_response.present?
           render json: token_response.merge(user: mobile_user_payload(user)), status: :created
         else
           render json: { errors: user.errors.full_messages }, status: :unprocessable_entity
@@ -186,6 +191,11 @@ module Api
           return
         end
 
+        if invite_only_default_family_missing? && invitation.blank?
+          render json: { error: "Invite-only default family is unavailable. Please contact an administrator." }, status: :forbidden
+          return
+        end
+
         # Atomically claim the code before creating the user
         return render json: { error: "Linking code is invalid or expired" }, status: :unauthorized unless consume_linking_code!(linking_code)
 
@@ -196,17 +206,11 @@ module Api
           skip_password_validation: true
         )
 
-        if invitation.present?
-          # Accept the pending invitation: join the existing family
-          user.family_id = invitation.family_id
-          user.role = invitation.role
-        else
-          user.family = Family.new
-
-          provider_config = Rails.configuration.x.auth.sso_providers&.find { |p| p[:name] == cached[:provider] }
-          provider_default_role = provider_config&.dig(:settings, :default_role)
-          user.role = User.role_for_new_family_creator(fallback_role: provider_default_role || :admin)
-        end
+        assign_signup_family_and_role(
+          user,
+          invitation: invitation,
+          new_family_fallback_role: sso_provider_default_role(cached[:provider]) || :admin
+        )
 
         if user.save
           # Mark invitation as accepted if one was used
@@ -289,6 +293,12 @@ module Api
 
         def user_signup_params
           params.require(:user).permit(:email, :password, :first_name, :last_name)
+        end
+
+        def pending_invitation_from_params
+          token = params[:invitation]
+          token ||= params[:user][:invitation] if params[:user].present?
+          Invitation.pending.find_by(token: token)
         end
 
         def validate_password(password)

--- a/app/controllers/concerns/invitable.rb
+++ b/app/controllers/concerns/invitable.rb
@@ -9,10 +9,46 @@ module Invitable
     def invite_code_required?
       return false if @invitation.present?
       if self_hosted?
-        Setting.onboarding_state == "invite_only" && Setting.invite_only_default_family_id.blank?
+        Setting.onboarding_state == "invite_only" && invite_only_default_family.blank?
       else
         ENV["REQUIRE_INVITE_CODE"] == "true"
       end
+    end
+
+    def assign_signup_family_and_role(user, invitation: nil, new_family_fallback_role: :admin)
+      if invitation.present?
+        user.family = invitation.family
+        user.role = invitation.role
+        user.email = invitation.email if user.respond_to?(:email=)
+      elsif (default_family = invite_only_default_family)
+        user.family = default_family
+        user.role = :member
+      else
+        user.family = Family.new
+        user.role = User.role_for_new_family_creator(fallback_role: new_family_fallback_role)
+      end
+    end
+
+    def sso_provider_default_role(provider_name)
+      provider_config = Rails.configuration.x.auth.sso_providers&.find do |provider|
+        provider[:name] == provider_name || provider[:id] == provider_name
+      end
+      settings = provider_config&.dig(:settings)
+
+      settings&.dig(:default_role) || settings&.dig("default_role")
+    end
+
+    def invite_only_default_family
+      default_family_id = Setting.invite_only_default_family_id
+      return unless default_family_id.present? && Setting.onboarding_state == "invite_only"
+
+      Family.find_by(id: default_family_id)
+    end
+
+    def invite_only_default_family_missing?
+      Setting.onboarding_state == "invite_only" &&
+        Setting.invite_only_default_family_id.present? &&
+        invite_only_default_family.blank?
     end
 
     def self_hosted?

--- a/app/controllers/oidc_accounts_controller.rb
+++ b/app/controllers/oidc_accounts_controller.rb
@@ -108,6 +108,11 @@ class OidcAccountsController < ApplicationController
       return
     end
 
+    if invite_only_default_family_missing? && invitation.blank?
+      redirect_to new_session_path, alert: "Invite-only default family is unavailable. Please contact an administrator."
+      return
+    end
+
     # Create SSO-only user without local password.
     # Security: JIT users should NOT have password_digest set to prevent
     # chained authentication attacks where SSO users gain local login access
@@ -121,20 +126,11 @@ class OidcAccountsController < ApplicationController
       skip_password_validation: true
     )
 
-    if invitation.present?
-      # Accept the pending invitation: join the existing family
-      @user.family_id = invitation.family_id
-      @user.role = invitation.role
-    else
-      # Create new family for this user
-      @user.family = Family.new
-
-      # Use provider-configured default role, or fall back to admin for family creators
-      # First user of an instance always becomes super_admin regardless of provider config
-      provider_config = Rails.configuration.x.auth.sso_providers&.find { |p| p[:name] == @pending_auth["provider"] }
-      provider_default_role = provider_config&.dig(:settings, :default_role)
-      @user.role = User.role_for_new_family_creator(fallback_role: provider_default_role || :admin)
-    end
+    assign_signup_family_and_role(
+      @user,
+      invitation: invitation,
+      new_family_fallback_role: sso_provider_default_role(@pending_auth["provider"]) || :admin
+    )
 
     if @user.save
       # Create the OIDC (or other SSO) identity

--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -14,20 +14,7 @@ class RegistrationsController < ApplicationController
   end
 
   def create
-    if @invitation
-      @user.family = @invitation.family
-      @user.role = @invitation.role
-      @user.email = @invitation.email
-    elsif (default_family_id = Setting.invite_only_default_family_id).present? &&
-          Setting.onboarding_state == "invite_only" &&
-          (default_family = Family.find_by(id: default_family_id))
-      @user.family = default_family
-      @user.role = :member
-    else
-      family = Family.new
-      @user.family = family
-      @user.role = User.role_for_new_family_creator
-    end
+    assign_signup_family_and_role(@user, invitation: @invitation)
 
     if @user.save
       @invitation&.update!(accepted_at: Time.current)

--- a/app/controllers/settings/hostings_controller.rb
+++ b/app/controllers/settings/hostings_controller.rb
@@ -46,8 +46,7 @@ class Settings::HostingsController < ApplicationController
     end
 
     if hosting_params.key?(:invite_only_default_family_id)
-      value = hosting_params[:invite_only_default_family_id].presence
-      Setting.invite_only_default_family_id = value
+      Setting.invite_only_default_family_id = invite_only_default_family_id_param
     end
 
     if hosting_params.key?(:brand_fetch_client_id)
@@ -200,6 +199,13 @@ class Settings::HostingsController < ApplicationController
     def hosting_params
       return ActionController::Parameters.new unless params.key?(:setting)
       params.require(:setting).permit(:onboarding_state, :require_email_confirmation, :invite_only_default_family_id, :brand_fetch_client_id, :brand_fetch_high_res_logos, :twelve_data_api_key, :tiingo_api_key, :eodhd_api_key, :alpha_vantage_api_key, :openai_access_token, :openai_uri_base, :openai_model, :openai_json_mode, :exchange_rate_provider, :securities_provider, :syncs_include_pending, :auto_sync_enabled, :auto_sync_time, :external_assistant_url, :external_assistant_token, :external_assistant_agent_id, securities_providers: [])
+    end
+
+    def invite_only_default_family_id_param
+      value = hosting_params[:invite_only_default_family_id].presence
+      return unless value.present?
+
+      Family.exists?(id: value) ? value : nil
     end
 
     def update_assistant_type

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -270,7 +270,6 @@ components:
       required:
       - id
       - name
-      - classification
       - color
       - icon
       properties:
@@ -278,8 +277,6 @@ components:
           type: string
           format: uuid
         name:
-          type: string
-        classification:
           type: string
         color:
           type: string
@@ -301,7 +298,6 @@ components:
       required:
       - id
       - name
-      - classification
       - color
       - icon
       - subcategories_count
@@ -313,11 +309,6 @@ components:
           format: uuid
         name:
           type: string
-        classification:
-          type: string
-          enum:
-          - income
-          - expense
         color:
           type: string
         icon:
@@ -539,13 +530,6 @@ components:
           type: string
           format: date-time
     DeleteResponse:
-      type: object
-      required:
-      - message
-      properties:
-        message:
-          type: string
-    SuccessMessage:
       type: object
       required:
       - message
@@ -879,50 +863,47 @@ components:
             "$ref": "#/components/schemas/Holding"
         pagination:
           "$ref": "#/components/schemas/Pagination"
+    Money:
+      type: object
+      required:
+      - amount
+      - currency
+      - formatted
+      properties:
+        amount:
+          type: string
+          description: Numeric amount as string
+        currency:
+          type: string
+          description: ISO 4217 currency code
+        formatted:
+          type: string
+          description: Locale-formatted money string
+    BalanceSheet:
+      type: object
+      required:
+      - currency
+      - net_worth
+      - assets
+      - liabilities
+      properties:
+        currency:
+          type: string
+          description: Family primary currency
+        net_worth:
+          "$ref": "#/components/schemas/Money"
+        assets:
+          "$ref": "#/components/schemas/Money"
+        liabilities:
+          "$ref": "#/components/schemas/Money"
+    SuccessMessage:
+      type: object
+      required:
+      - message
+      properties:
+        message:
+          type: string
 paths:
-  "/api/v1/merchants":
-    get:
-      summary: List merchants
-      tags:
-      - Merchants
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          description: merchants listed
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/MerchantDetail"
-  "/api/v1/merchants/{id}":
-    parameters:
-    - name: id
-      in: path
-      required: true
-      description: Merchant ID
-      schema:
-        type: string
-    get:
-      summary: Retrieve a merchant
-      tags:
-      - Merchants
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          description: merchant retrieved
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/MerchantDetail"
-        '404':
-          description: merchant not found
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v1/accounts":
     get:
       summary: List accounts
@@ -1026,6 +1007,11 @@ paths:
                       type: string
                     last_name:
                       type: string
+                    invitation:
+                      type: string
+                      nullable: true
+                      description: Pending invitation token; joins the invited family
+                        when valid
                   required:
                   - email
                   - password
@@ -1055,6 +1041,11 @@ paths:
                   type: string
                   nullable: true
                   description: Invite code (required when invites are enforced)
+                invitation:
+                  type: string
+                  nullable: true
+                  description: Pending invitation token; joins the invited family
+                    when valid
               required:
               - user
               - device
@@ -1267,6 +1258,181 @@ paths:
               - refresh_token
               - device
         required: true
+  "/api/v1/auth/sso_link":
+    post:
+      summary: Link an existing account via SSO
+      tags:
+      - Auth
+      description: Authenticates with email/password and links the SSO identity from
+        a previously issued linking code. Creates an OidcIdentity, logs the link via
+        SsoAuditLog, and issues mobile OAuth tokens.
+      parameters: []
+      responses:
+        '200':
+          description: account linked and tokens issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                  refresh_token:
+                    type: string
+                  token_type:
+                    type: string
+                  expires_in:
+                    type: integer
+                  created_at:
+                    type: integer
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      email:
+                        type: string
+                      first_name:
+                        type: string
+                      last_name:
+                        type: string
+                      ui_layout:
+                        type: string
+                        enum:
+                        - dashboard
+                        - intro
+                      ai_enabled:
+                        type: boolean
+        '400':
+          description: missing linking code
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '401':
+          description: invalid credentials or expired linking code
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                linking_code:
+                  type: string
+                  description: One-time linking code from mobile SSO onboarding redirect
+                email:
+                  type: string
+                  format: email
+                  description: Email of the existing account to link
+                password:
+                  type: string
+                  description: Password for the existing account
+              required:
+              - linking_code
+              - email
+              - password
+        required: true
+  "/api/v1/auth/sso_create_account":
+    post:
+      summary: Create a new account via SSO
+      tags:
+      - Auth
+      description: Creates a new user from a previously issued linking code. The user
+        joins a pending invitation family, the configured invite-only default family,
+        or otherwise a new family. Links the SSO identity via OidcIdentity, logs the
+        JIT account creation via SsoAuditLog, and issues mobile OAuth tokens. The
+        linking code must have allow_account_creation enabled unless a pending invitation
+        exists.
+      parameters: []
+      responses:
+        '200':
+          description: account created and tokens issued
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  access_token:
+                    type: string
+                  refresh_token:
+                    type: string
+                  token_type:
+                    type: string
+                  expires_in:
+                    type: integer
+                  created_at:
+                    type: integer
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      email:
+                        type: string
+                      first_name:
+                        type: string
+                      last_name:
+                        type: string
+                      ui_layout:
+                        type: string
+                        enum:
+                        - dashboard
+                        - intro
+                      ai_enabled:
+                        type: boolean
+        '400':
+          description: missing linking code
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '401':
+          description: invalid or expired linking code
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: account creation disabled
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+        '422':
+          description: user validation error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  errors:
+                    type: array
+                    items:
+                      type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                linking_code:
+                  type: string
+                  description: One-time linking code from mobile SSO onboarding redirect
+                first_name:
+                  type: string
+                  description: First name (overrides value from SSO provider if provided)
+                last_name:
+                  type: string
+                  description: Last name (overrides value from SSO provider if provided)
+              required:
+              - linking_code
+        required: true
   "/api/v1/auth/enable_ai":
     patch:
       summary: Enable AI features for the authenticated user
@@ -1309,6 +1475,30 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+        '403':
+          description: insufficient scope
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/balance_sheet":
+    get:
+      summary: Show balance sheet
+      tags:
+      - Balance Sheet
+      description: Returns the family balance sheet including net worth, total assets,
+        and total liabilities with amounts converted to the family's primary currency.
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: balance sheet returned
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/BalanceSheet"
+        '401':
+          description: unauthorized
   "/api/v1/categories":
     get:
       summary: List categories
@@ -1329,15 +1519,6 @@ paths:
         description: 'Items per page (default: 25, max: 100)'
         schema:
           type: integer
-      - name: classification
-        in: query
-        required: false
-        description: Filter by classification (income or expense)
-        schema:
-          type: string
-          enum:
-          - income
-          - expense
       - name: roots_only
         in: query
         required: false
@@ -1879,6 +2060,49 @@ paths:
                 "$ref": "#/components/schemas/ImportResponse"
         '404':
           description: import not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/merchants":
+    get:
+      summary: List merchants
+      tags:
+      - Merchants
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: merchants listed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/MerchantDetail"
+  "/api/v1/merchants/{id}":
+    parameters:
+    - name: id
+      in: path
+      required: true
+      description: Merchant ID
+      schema:
+        type: string
+    get:
+      summary: Retrieve a merchant
+      tags:
+      - Merchants
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: merchant retrieved
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/MerchantDetail"
+        '404':
+          description: merchant not found
           content:
             application/json:
               schema:
@@ -2583,6 +2807,53 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/ErrorResponse"
+  "/api/v1/users/reset":
+    delete:
+      summary: Reset account
+      tags:
+      - Users
+      description: Resets all financial data (accounts, categories, merchants, tags,
+        etc.) for the current user's family while keeping the user account intact.
+        The reset runs asynchronously in the background. Requires admin role.
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: account reset initiated
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SuccessMessage"
+        '401':
+          description: unauthorized
+        '403':
+          description: forbidden - requires read_write scope and admin role
+  "/api/v1/users/me":
+    delete:
+      summary: Delete account
+      tags:
+      - Users
+      description: Permanently deactivates the current user account and all associated
+        data. This action cannot be undone.
+      security:
+      - apiKeyAuth: []
+      responses:
+        '200':
+          description: account deleted
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/SuccessMessage"
+        '401':
+          description: unauthorized
+        '403':
+          description: insufficient scope
+        '422':
+          description: deactivation failed
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ErrorResponse"
   "/api/v1/valuations":
     post:
       summary: Create valuation
@@ -2725,66 +2996,3 @@ paths:
                       type: string
                       description: Additional notes
         required: true
-  "/api/v1/users/reset":
-    delete:
-      summary: Reset account
-      tags:
-      - Users
-      description: Resets all financial data (accounts, categories, merchants, tags,
-        etc.) for the current user's family while keeping the user account intact.
-        The reset runs asynchronously in the background. Requires admin role.
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          description: account reset initiated
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/SuccessMessage"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '403':
-          description: "forbidden \u2014 requires read_write scope and admin role"
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-  "/api/v1/users/me":
-    delete:
-      summary: Delete account
-      tags:
-      - Users
-      description: Permanently deactivates the current user account and all associated
-        data. This action cannot be undone.
-      security:
-      - apiKeyAuth: []
-      responses:
-        '200':
-          description: account deleted
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/SuccessMessage"
-        '401':
-          description: unauthorized
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '403':
-          description: insufficient scope
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"
-        '422':
-          description: deactivation failed
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/ErrorResponse"

--- a/spec/requests/api/v1/auth_spec.rb
+++ b/spec/requests/api/v1/auth_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'API V1 Auth', type: :request do
               email: { type: :string, format: :email, description: 'User email address' },
               password: { type: :string, description: 'Password (min 8 chars, mixed case, number, special char)' },
               first_name: { type: :string },
-              last_name: { type: :string }
+              last_name: { type: :string },
+              invitation: { type: :string, nullable: true, description: 'Pending invitation token; joins the invited family when valid' }
             },
             required: %w[email password]
           },
@@ -32,7 +33,8 @@ RSpec.describe 'API V1 Auth', type: :request do
             },
             required: %w[device_id device_name device_type os_version app_version]
           },
-          invite_code: { type: :string, nullable: true, description: 'Invite code (required when invites are enforced)' }
+          invite_code: { type: :string, nullable: true, description: 'Invite code (required when invites are enforced)' },
+          invitation: { type: :string, nullable: true, description: 'Pending invitation token; joins the invited family when valid' }
         },
         required: %w[user device]
       }
@@ -272,7 +274,7 @@ RSpec.describe 'API V1 Auth', type: :request do
       tags 'Auth'
       consumes 'application/json'
       produces 'application/json'
-      description 'Creates a new user and family from a previously issued linking code. Links the SSO identity via OidcIdentity, logs the JIT account creation via SsoAuditLog, and issues mobile OAuth tokens. The linking code must have allow_account_creation enabled.'
+      description 'Creates a new user from a previously issued linking code. The user joins a pending invitation family, the configured invite-only default family, or otherwise a new family. Links the SSO identity via OidcIdentity, logs the JIT account creation via SsoAuditLog, and issues mobile OAuth tokens. The linking code must have allow_account_creation enabled unless a pending invitation exists.'
       parameter name: :body, in: :body, required: true, schema: {
         type: :object,
         properties: {

--- a/test/controllers/api/v1/auth_controller_test.rb
+++ b/test/controllers/api/v1/auth_controller_test.rb
@@ -26,9 +26,14 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
     # Use a real cache store for SSO linking tests (test env uses :null_store by default)
     @original_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new
+
+    @original_onboarding_state = Setting.onboarding_state
+    @original_invite_only_default_family_id = Setting.invite_only_default_family_id
   end
 
   teardown do
+    Setting.onboarding_state = @original_onboarding_state unless @original_onboarding_state.nil?
+    Setting.invite_only_default_family_id = @original_invite_only_default_family_id
     Rails.cache = @original_cache if @original_cache
   end
 
@@ -147,6 +152,55 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
     new_user = User.find(response_data["user"]["id"])
     assert_equal "admin", new_user.role
     assert new_user.family.present?
+  end
+
+  test "signup joins configured invite-only default family as member" do
+    default_family = families(:empty)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+
+    assert_no_difference("Family.count") do
+      post "/api/v1/auth/signup", params: {
+        user: {
+          email: "defaultfamily@example.com",
+          password: "SecurePass123!",
+          first_name: "Default",
+          last_name: "Family"
+        },
+        device: @device_info
+      }
+    end
+
+    assert_response :created
+    user = User.find_by!(email: "defaultfamily@example.com")
+    assert_equal default_family, user.family
+    assert_equal "member", user.role
+  end
+
+  test "signup accepts pending invitation before invite-only default family" do
+    default_family = families(:empty)
+    invitation = invitations(:two)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+
+    assert_no_difference("Family.count") do
+      post "/api/v1/auth/signup", params: {
+        user: {
+          email: "ignored@example.com",
+          password: "SecurePass123!",
+          first_name: "Invited",
+          last_name: "User",
+          invitation: invitation.token
+        },
+        device: @device_info
+      }
+    end
+
+    assert_response :created
+    user = User.find_by!(email: invitation.email)
+    assert_equal invitation.family, user.family
+    assert_equal invitation.role, user.role
+    assert_not_nil invitation.reload.accepted_at
   end
 
   test "should require invite code when enabled" do
@@ -684,6 +738,133 @@ class Api::V1::AuthControllerTest < ActionDispatch::IntegrationTest
 
     # Linking code should be consumed
     assert_nil Rails.cache.read("mobile_sso_link:#{linking_code}")
+  end
+
+  test "sso_create_account uses provider default role for new family JIT users" do
+    Rails.configuration.x.auth.stubs(:sso_providers).returns([
+      { name: "google_oauth2", settings: { default_role: "member" } }
+    ])
+
+    linking_code = SecureRandom.urlsafe_base64(32)
+    Rails.cache.write("mobile_sso_link:#{linking_code}", {
+      provider: "google_oauth2",
+      uid: "google-uid-provider-role",
+      email: "providerrole@example.com",
+      first_name: "Provider",
+      last_name: "Role",
+      name: "Provider Role",
+      device_info: @device_info.stringify_keys,
+      allow_account_creation: true
+    }, expires_in: 10.minutes)
+
+    assert_difference([ "User.count", "OidcIdentity.count", "Family.count" ], 1) do
+      post "/api/v1/auth/sso_create_account", params: {
+        linking_code: linking_code,
+        first_name: "Provider",
+        last_name: "Role"
+      }
+    end
+
+    assert_response :success
+    user = User.find_by!(email: "providerrole@example.com")
+    assert_equal "member", user.role
+  end
+
+  test "sso_create_account rejects stale invite-only default family without consuming linking code" do
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = SecureRandom.uuid
+
+    linking_code = SecureRandom.urlsafe_base64(32)
+    Rails.cache.write("mobile_sso_link:#{linking_code}", {
+      provider: "google_oauth2",
+      uid: "google-uid-stale-default",
+      email: "stalesso@example.com",
+      first_name: "Stale",
+      last_name: "Sso",
+      name: "Stale Sso",
+      device_info: @device_info.stringify_keys,
+      allow_account_creation: true
+    }, expires_in: 10.minutes)
+
+    assert_no_difference([ "User.count", "OidcIdentity.count", "Family.count" ]) do
+      post "/api/v1/auth/sso_create_account", params: {
+        linking_code: linking_code,
+        first_name: "Stale",
+        last_name: "Sso"
+      }
+    end
+
+    assert_response :forbidden
+    assert_equal "Invite-only default family is unavailable. Please contact an administrator.", JSON.parse(response.body)["error"]
+    assert Rails.cache.read("mobile_sso_link:#{linking_code}").present?
+  end
+
+  test "sso_create_account joins configured invite-only default family as member" do
+    default_family = families(:empty)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+
+    linking_code = SecureRandom.urlsafe_base64(32)
+    Rails.cache.write("mobile_sso_link:#{linking_code}", {
+      provider: "google_oauth2",
+      uid: "google-uid-default-family",
+      email: "defaultsso@example.com",
+      first_name: "Default",
+      last_name: "Sso",
+      name: "Default Sso",
+      device_info: @device_info.stringify_keys,
+      allow_account_creation: true
+    }, expires_in: 10.minutes)
+
+    assert_difference([ "User.count", "OidcIdentity.count" ], 1) do
+      assert_no_difference("Family.count") do
+        post "/api/v1/auth/sso_create_account", params: {
+          linking_code: linking_code,
+          first_name: "Default",
+          last_name: "Sso"
+        }
+      end
+    end
+
+    assert_response :success
+    user = User.find_by!(email: "defaultsso@example.com")
+    assert_equal default_family, user.family
+    assert_equal "member", user.role
+  end
+
+  test "sso_create_account accepts pending invitation before invite-only default family" do
+    default_family = families(:empty)
+    invitation = invitations(:two)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+
+    linking_code = SecureRandom.urlsafe_base64(32)
+    Rails.cache.write("mobile_sso_link:#{linking_code}", {
+      provider: "google_oauth2",
+      uid: "google-uid-invited-family",
+      email: invitation.email,
+      first_name: "Invited",
+      last_name: "Sso",
+      name: "Invited Sso",
+      device_info: @device_info.stringify_keys,
+      allow_account_creation: true
+    }, expires_in: 10.minutes)
+
+    assert_difference([ "User.count", "OidcIdentity.count" ], 1) do
+      assert_no_difference("Family.count") do
+        post "/api/v1/auth/sso_create_account", params: {
+          linking_code: linking_code,
+          first_name: "Invited",
+          last_name: "Sso"
+        }
+      end
+    end
+
+    assert_response :success
+    user = User.find_by!(email: invitation.email)
+    assert_equal invitation.family, user.family
+    assert_equal invitation.role, user.role
+    assert_not_nil invitation.reload.accepted_at
   end
 
   test "should reject SSO create account when not allowed" do

--- a/test/controllers/oidc_accounts_controller_test.rb
+++ b/test/controllers/oidc_accounts_controller_test.rb
@@ -2,7 +2,15 @@ require "test_helper"
 
 class OidcAccountsControllerTest < ActionController::TestCase
   setup do
+    ensure_tailwind_build
     @user = users(:family_admin)
+    @original_onboarding_state = Setting.onboarding_state
+    @original_invite_only_default_family_id = Setting.invite_only_default_family_id
+  end
+
+  teardown do
+    Setting.onboarding_state = @original_onboarding_state unless @original_onboarding_state.nil?
+    Setting.invite_only_default_family_id = @original_invite_only_default_family_id
   end
 
   def pending_auth
@@ -187,6 +195,72 @@ class OidcAccountsControllerTest < ActionController::TestCase
     assert_equal new_user_auth["uid"], oidc_identity.uid
   end
 
+  test "create_user uses provider default role for new family JIT users" do
+    Rails.configuration.x.auth.stubs(:sso_providers).returns([
+      { name: "openid_connect", settings: { default_role: "guest" } }
+    ])
+    session[:pending_oidc_auth] = new_user_auth
+
+    assert_difference([ "User.count", "OidcIdentity.count", "Family.count" ], 1) do
+      post :create_user
+    end
+
+    assert_redirected_to root_path
+    new_user = User.find_by!(email: new_user_auth["email"])
+    assert_equal "guest", new_user.role
+  end
+
+  test "create_user rejects stale invite-only default family" do
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = SecureRandom.uuid
+    session[:pending_oidc_auth] = new_user_auth
+
+    assert_no_difference([ "User.count", "OidcIdentity.count", "Family.count" ]) do
+      post :create_user
+    end
+
+    assert_redirected_to new_session_path
+    assert_equal "Invite-only default family is unavailable. Please contact an administrator.", flash[:alert]
+  end
+
+  test "create_user joins configured invite-only default family as member" do
+    default_family = families(:empty)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+    session[:pending_oidc_auth] = new_user_auth
+
+    assert_difference([ "User.count", "OidcIdentity.count" ], 1) do
+      assert_no_difference("Family.count") do
+        post :create_user
+      end
+    end
+
+    assert_redirected_to root_path
+    new_user = User.find_by!(email: new_user_auth["email"])
+    assert_equal default_family, new_user.family
+    assert_equal "member", new_user.role
+  end
+
+  test "create_user accepts pending invitation before invite-only default family" do
+    default_family = families(:empty)
+    invitation = invitations(:two)
+    Setting.onboarding_state = "invite_only"
+    Setting.invite_only_default_family_id = default_family.id.to_s
+    session[:pending_oidc_auth] = new_user_auth.merge("email" => invitation.email)
+
+    assert_difference([ "User.count", "OidcIdentity.count" ], 1) do
+      assert_no_difference("Family.count") do
+        post :create_user
+      end
+    end
+
+    assert_redirected_to root_path
+    new_user = User.find_by!(email: invitation.email)
+    assert_equal invitation.family, new_user.family
+    assert_equal invitation.role, new_user.role
+    assert_not_nil invitation.reload.accepted_at
+  end
+
   test "create_user uses form params for name when provided" do
     session[:pending_oidc_auth] = new_user_auth
 
@@ -257,4 +331,12 @@ class OidcAccountsControllerTest < ActionController::TestCase
       password: "anypassword"
     ), "SSO-only user should not authenticate with password"
   end
+
+  private
+
+    def ensure_tailwind_build
+      tailwind_build = Rails.root.join("app/assets/builds/tailwind.css")
+      FileUtils.mkdir_p(tailwind_build.dirname)
+      File.write(tailwind_build, "/* test */") unless tailwind_build.exist?
+    end
 end

--- a/test/controllers/settings/hostings_controller_test.rb
+++ b/test/controllers/settings/hostings_controller_test.rb
@@ -5,6 +5,7 @@ class Settings::HostingsControllerTest < ActionDispatch::IntegrationTest
   include ProviderTestHelper
 
   setup do
+    ensure_tailwind_build
     sign_in users(:family_admin)
 
     @provider = mock
@@ -314,4 +315,39 @@ class Settings::HostingsControllerTest < ActionDispatch::IntegrationTest
   ensure
     Setting.securities_providers = ""
   end
+
+  test "can update invite-only default family when it exists" do
+    sign_in users(:sure_support_staff)
+    family = families(:empty)
+
+    with_self_hosting do
+      patch settings_hosting_url, params: { setting: { invite_only_default_family_id: family.id.to_s } }
+
+      assert_redirected_to settings_hosting_url
+      assert_equal family.id.to_s, Setting.invite_only_default_family_id
+    end
+  ensure
+    Setting.invite_only_default_family_id = nil
+  end
+
+  test "clears invite-only default family when submitted family is stale" do
+    sign_in users(:sure_support_staff)
+
+    with_self_hosting do
+      patch settings_hosting_url, params: { setting: { invite_only_default_family_id: SecureRandom.uuid } }
+
+      assert_redirected_to settings_hosting_url
+      assert_nil Setting.invite_only_default_family_id
+    end
+  ensure
+    Setting.invite_only_default_family_id = nil
+  end
+
+  private
+
+    def ensure_tailwind_build
+      tailwind_build = Rails.root.join("app/assets/builds/tailwind.css")
+      FileUtils.mkdir_p(tailwind_build.dirname)
+      File.write(tailwind_build, "/* test */") unless tailwind_build.exist?
+    end
 end


### PR DESCRIPTION
### Motivation
- Align API/mobile signup and SSO JIT account creation with the web signup precedence so pending invitations win first, configured invite-only default family is used next, and otherwise a new family is created for the user.
- Preserve SSO provider-configured default roles for JIT-created new families and avoid silently storing stale invite-only default family IDs.

### Description
- Introduce shared `Invitable` helpers: `assign_signup_family_and_role`, `invite_only_default_family`, `invite_only_default_family_missing?`, and `sso_provider_default_role` to centralize family/role assignment logic across web, API, and SSO flows.
- API signup (`Api::V1::AuthController#signup`) now resolves a pending invitation token before invite-code checks, uses the shared assignment helper, runs user creation + invite claim + device/token issuance inside a transaction, and marks invitations accepted on success.
- Mobile SSO (`sso_create_account`) and OIDC JIT (`OidcAccountsController#create_user`) use the shared helper, preserve provider default roles for new-family JIT users, and reject SSO creation when the configured invite-only default family ID is stale.
- Web registration (`RegistrationsController#create`) now reuses the shared assignment helper for consistent behavior.
- Hosting settings validation: `Settings::HostingsController` now sanitizes `invite_only_default_family_id` via `invite_only_default_family_id_param` to clear stale IDs instead of persisting them.
- OpenAPI/rswag docs updated to document the `invitation` token in API signup and to clarify SSO create-account behavior.
- Tests: added/updated Minitest coverage for API signup, SSO create-account, OIDC JIT flows, stale default-family rejection, provider default roles, and hosting settings; updated RSpec rswag request spec docs.

### Testing
- Ran targeted Rails tests: `bin/rails test test/controllers/api/v1/auth_controller_test.rb test/controllers/oidc_accounts_controller_test.rb test/controllers/settings/hostings_controller_test.rb` and they all passed (88 runs, 398 assertions, 0 failures, 0 errors).
- Regenerated API docs with `RAILS_ENV=test bundle exec rake rswag:specs:swaggerize` and `docs/api/openapi.yaml` was produced successfully.
- Ran `bin/rubocop` on modified files with no offenses detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1af539310c83329c471d57a5e24139)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Pending invitations now integrated directly into signup flow
  * New SSO authentication endpoints for account linking and creation
  * Added balance sheet endpoint for financial data retrieval

* **Improvements**
  * Enhanced data consistency during account creation
  * Improved server-side validation for invite-only family configurations
  * Strengthened error handling in signup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->